### PR TITLE
Portability fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ ecbuild_add_option( FEATURE SINGLE_PRECISION
                     DEFAULT ON
                     DESCRIPTION "Support for Single Precision" )
 
+ecbuild_add_option( FEATURE DUMMY_MPI_HEADER
+                    DEFAULT ON
+                    DESCRIPTION "[DANGEROUS] Install a dummy MPI header" )
+
 ecbuild_add_option( FEATURE WARNINGS
                     DEFAULT ON
                     DESCRIPTION "Add warnings to compiler" )

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Extra options can be added to the `cmake` command to control the build:
  - `-DENABLE_DOUBLE_PRECISION=<ON|OFF>` default=ON
  - `-DENABLE_MPI=<ON|OFF>` 
  - `-DENABLE_OMP=<ON|OFF>`
+ - `-DENABLE_DUMMY_MPI_HEADER=<ON|OFF>` default=ON
  - `-DCMAKE_INSTALL_PREFIX=<install-prefix>`
 
 More options to control compilation flags, only when defaults are not sufficient

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -32,9 +32,9 @@ if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
 endif()
 
 if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
-  ecbuild_add_fortran_flags( -ffree-line-length-none )
+  ecbuild_add_fortran_flags( -ffree-line-length-none NO_FAIL )
   if( CMAKE_Fortran_COMPILER_VERSION GREATER_EQUAL 10 )
-      ecbuild_add_fortran_flags( -fallow-argument-mismatch )
+      ecbuild_add_fortran_flags( -fallow-argument-mismatch NO_FAIL )
   endif()
 endif()
 

--- a/src/fiat/util/ec_env.c
+++ b/src/fiat/util/ec_env.c
@@ -282,7 +282,7 @@ void ec_gethostname(char a[],
 
 /* ec_coreid(): For checking runtime affinities (not setting them, though) */
 
-#if defined(LINUX) && !defined(__NEC__)
+#if defined(LINUX)
 #include <sched.h>
 int sched_getcpu(void);
 #define getcpu() sched_getcpu()

--- a/src/mpi_serial/CMakeLists.txt
+++ b/src/mpi_serial/CMakeLists.txt
@@ -85,9 +85,14 @@ ecbuild_add_library( TARGET mpi_serial
 
 ## Install and Export ##
 
-install(
-    FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/mpif.h
-    DESTINATION
-        include/mpi_serial
-)
+if( ${HAVE_DUMMY_MPI_HEADER} )
+
+  install(
+      FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/mpif.h
+      DESTINATION
+          include/mpi_serial
+  )
+
+endif()
+


### PR DESCRIPTION
- option ENABLE_DUMMY_MPI_HEADER (to be explicitely set to OFF inside gmkpack, for safety)
- portability fix for NEC Aurora